### PR TITLE
Handle meaning type parameters in codegen

### DIFF
--- a/src/compiler/codegen.c
+++ b/src/compiler/codegen.c
@@ -266,6 +266,17 @@ static int generate_function(ast_node_t *func, FILE *file) {
           if (param->children[j]->type == AST_BASIC_TYPE) {
             param_type = ast_get_string(param->children[j], "type");
             break;
+          } else if (param->children[j]->type == AST_MEANING_TYPE) {
+            // Meaning types wrap a basic type; extract the base type
+            ast_node_t *meaning = param->children[j];
+            for (int k = 0; k < meaning->child_count; k++) {
+              if (meaning->children[k]->type == AST_BASIC_TYPE) {
+                param_type =
+                    ast_get_string(meaning->children[k], "type");
+                break;
+              }
+            }
+            break;
           }
         }
 


### PR DESCRIPTION
## Summary
- refine `generate_function` parameter handling
- extract base type when parameter uses a `Meaning` type
- map that base type to the corresponding C type

## Testing
- `make parser`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6841a4c6d34c8332bd6becf402ba9f50