### PR TITLE
Use return type meaning for prompt execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ API keys can also be provided via environment variables:
 - C compiler (GCC or Clang)
 - CMake 3.10+
 - libcurl and cJSON development libraries
+- Bison and Flex (for building the parser)
 
 ### Installation
 

--- a/tests/unit/data/function_with_vars.expected.c
+++ b/tests/unit/data/function_with_vars.expected.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 // Forward declarations for runtime functions
-extern VibeValue *vibe_execute_prompt(const char *prompt);
+extern VibeValue *vibe_execute_prompt(const char *prompt, const char *meaning);
 extern char *format_prompt(const char *template, char **var_names,
                            char **var_values, int var_count);
 
@@ -37,7 +37,7 @@ Weather getWeather(const char *city, const char *day) {
     var_values[3] = strdup(when ? when : "");
     char *formatted_prompt =
         format_prompt(prompt_template, var_names, var_values, var_count);
-    prompt_result = vibe_execute_prompt(formatted_prompt);
+    prompt_result = vibe_execute_prompt(formatted_prompt, "weather description");
     if (prompt_result) {
       // Convert LLM response to the appropriate return type
       return vibe_value_get_string(prompt_result);

--- a/tests/unit/data/simple_function.expected.c
+++ b/tests/unit/data/simple_function.expected.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 // Forward declarations for runtime functions
-extern VibeValue *vibe_execute_prompt(const char *prompt);
+extern VibeValue *vibe_execute_prompt(const char *prompt, const char *meaning);
 extern char *format_prompt(const char *template, char **var_names,
                            char **var_values, int var_count);
 
@@ -28,7 +28,7 @@ int getTemperature(const char *city) {
     var_values[0] = strdup(city ? city : "");
     char *formatted_prompt =
         format_prompt(prompt_template, var_names, var_values, var_count);
-    prompt_result = vibe_execute_prompt(formatted_prompt);
+    prompt_result = vibe_execute_prompt(formatted_prompt, "temperature in Celsius");
     if (prompt_result) {
       // Convert LLM response to the appropriate return type
       return vibe_value_get_int(prompt_result);


### PR DESCRIPTION
## Summary
- add AST search helper to locate type declarations
- infer meaning from function return type in `generate_prompt_block`
- pass meaning to `vibe_execute_prompt`
- update expected codegen outputs
- document parser dependencies for local builds

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6841c47286fc8332945abefc1653503f