### PR TITLE
Implement module compile in runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,12 @@ add_library(vibelang SHARED
 
 # Add dependencies
 target_link_libraries(vibelang_utils PRIVATE ${CJSON_LIBRARIES})
-target_link_libraries(vibelang_runtime PRIVATE vibelang_utils ${CJSON_LIBRARIES} ${CURL_LIBRARIES})
+target_link_libraries(vibelang_runtime PRIVATE
+  vibelang_utils
+  vibelang_compiler
+  ${CJSON_LIBRARIES}
+  ${CURL_LIBRARIES}
+)
 target_link_libraries(vibelang_compiler PRIVATE vibelang_utils)
 target_link_libraries(vibelang PUBLIC 
   vibelang_utils 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,14 +57,16 @@ add_executable(test_llm_integration
 )
 
 # Link against the library
-target_link_libraries(test_llm_integration 
-  vibelang_runtime
-  vibelang_utils
+target_link_libraries(test_llm_integration
+  vibelang
 )
 
 # Add to CTest test suite
 add_test(NAME test_llm_integration
          COMMAND test_llm_integration)
+set_tests_properties(test_llm_integration PROPERTIES
+  ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+)
 
 # Create test data directory during build
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests/unit/data)


### PR DESCRIPTION
## Summary
- compile runtime modules when missing or outdated
- use `vibelang_compile` and gcc to produce shared library
- allow custom rpath flags via `VIBELANG_RPATH_FLAGS` environment variable

## Testing
- `make test` *(fails: Bison not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cc5da4f48332821e038106871ae2